### PR TITLE
Move through search results using next-error after visiting a result

### DIFF
--- a/deadgrep.el
+++ b/deadgrep.el
@@ -1167,6 +1167,7 @@ If POS is nil, use the beginning position of the current line."
       ;; consistent with `compilation-next-error-function' and also
       ;; useful with `deadgrep-visit-result-other-window'.
       (setq overlay-arrow-position (copy-marker pos))
+      (setq next-error-last-buffer (current-buffer))
 
       (funcall open-fn file-name)
       (goto-char (point-min))


### PR DESCRIPTION
This allows moving through search results with next-error after visiting a result. This seems to be consistent with how other modes (compilation, grep etc built on compilation, xref) operate. It is also how they achieve the behaviour.